### PR TITLE
Fix build, add go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 Replace <host> with your host
 
+### Build
+
+Go 1.13+. Build steps for older go versions may vary.
+
+```
+go build .
+ls ./libpostal-rest
+```
+
 ### Parser
 `curl -X POST -d '{"query": "100 main st buffalo ny"}' <host>:8080/parser`
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/johnlonganecker/libpostal-rest
+
+go 1.16
+
+require (
+	github.com/gorilla/mux v1.8.0
+	github.com/openvenues/gopostal v0.0.0-20171226154602-e0184512a45d
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/openvenues/gopostal v0.0.0-20171226154602-e0184512a45d h1:KJ+N55d9zLN8fTg3NchLdmmAmPieXC5E6UNJ8zFFttU=
+github.com/openvenues/gopostal v0.0.0-20171226154602-e0184512a45d/go.mod h1:Ycrd7XnwQdumHzpB/6WEa85B4WNdbLC6Wz4FAQNkaV0=


### PR DESCRIPTION
go has started to require go modules in recent versions, the files in this PR are now required.

Also extends the readme with build instructions.

Thanks!