### PR TITLE
add expandparser API command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,126 @@ ls ./libpostal-rest
   "100 main street buffalo ny"
 ]
 ```
+
+### Expand and Parse
+`curl -X POST -d '{"query": "100 main st buffalo ny"}' <host>:8080/expandparser`
+
+Original query is parsed and added with `"type": "query"`.  
+All query expansions are parsed and added with `"tpye": "expansion"`
+
+** Response **  
+
+```
+[
+    {
+        "data": "100 main st buffalo ny",
+        "parsed": [
+            {
+                "label": "house_number",
+                "value": "100"
+            },
+            {
+                "label": "road",
+                "value": "main st"
+            },
+            {
+                "label": "city",
+                "value": "buffalo"
+            },
+            {
+                "label": "state",
+                "value": "ny"
+            }
+        ],
+        "type": "query"
+    },
+    {
+        "data": "100 main saint buffalo ny",
+        "parsed": [
+            {
+                "label": "house_number",
+                "value": "100"
+            },
+            {
+                "label": "road",
+                "value": "main"
+            },
+            {
+                "label": "city",
+                "value": "saint buffalo"
+            },
+            {
+                "label": "state",
+                "value": "ny"
+            }
+        ],
+        "type": "expansion"
+    },
+    {
+        "data": "100 main saint buffalo new york",
+        "parsed": [
+            {
+                "label": "house_number",
+                "value": "100"
+            },
+            {
+                "label": "road",
+                "value": "main"
+            },
+            {
+                "label": "city",
+                "value": "saint buffalo"
+            },
+            {
+                "label": "state",
+                "value": "new york"
+            }
+        ],
+        "type": "expansion"
+    },
+    {
+        "data": "100 main street buffalo ny",
+        "parsed": [
+            {
+                "label": "house_number",
+                "value": "100"
+            },
+            {
+                "label": "road",
+                "value": "main street"
+            },
+            {
+                "label": "city",
+                "value": "buffalo"
+            },
+            {
+                "label": "state",
+                "value": "ny"
+            }
+        ],
+        "type": "expansion"
+    },
+    {
+        "data": "100 main street buffalo new york",
+        "parsed": [
+            {
+                "label": "house_number",
+                "value": "100"
+            },
+            {
+                "label": "road",
+                "value": "main street"
+            },
+            {
+                "label": "city",
+                "value": "buffalo"
+            },
+            {
+                "label": "state",
+                "value": "new york"
+            }
+        ],
+        "type": "expansion"
+    }
+]
+```


### PR DESCRIPTION
This PR adds another API command which allows the user to combine both already existing commands `expand`and `parser`.  
The `expandparser` command first expands the query and then parses both the original query and the expanded versions of the query, all adding to a JSON object list with 
- the first element representing the original query + parsing (indicated by `"type": "query"`)
- the subsequent elements representing the query expansions + parsings (indicated by `"type": "expansion"`)